### PR TITLE
🐛readthedocs dependency fix

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,14 +1,9 @@
-pip==19.2.3
 bump2version==0.5.11
 wheel==0.33.6
-watchdog==0.9.0
 flake8==3.7.8
 tox==3.14.0
 coverage==4.5.4
-Sphinx>=1.8.5
 twine==1.14.0
 pytest==4.6.5
 pytest-runner==5.1
-watchdog==0.9.0
-myst-parser
-sphinx-rtd-theme
+watchdog

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,0 +1,2 @@
+myst-parser
+sphinx-rtd-theme


### PR DESCRIPTION
Because we are using MyST, the dependencies must be installed in a separate `requirements_docs.txt`. Somehow, this fixes the dependency resolution.